### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# spring-boot-angular-examples
+# spring-boot-angular-test


### PR DESCRIPTION
Description in two sentences or less:

Apple Trade In: Voice over reads 'Yes' or 'No' as buttons without selecting it in Tradein flow. UIAccessibilityScreenChangedNotification was being posted for two UI components, $header and $disclaimer. This was leading to skipping the header being read out first and since the disclaimer is blank in this case the VO control was going to the just previous component of NO button

Testing Instructions

Steps To Reproduce:

Launch the Apple Store Application.
Navigate to the Mac/iPad/Apple Watch family landing page
Select any modal and go to Product description page
Select required variants to enable the 'Apple Trade In' section.
Click on 'Get started' link
Go to the 'Is your iPhone is good condition?' screen
By default reads as 'Yes' and 'No' without selecting buttons instead read firstly 'Header' texts.
Expected Results:

As soon as landing on the page then Voice Over should read header first i.e 'Is your iPhone in good condition.

Info

Is this a fix for something broken from the user perspective? What is broken?
Yes, voice over not reading header text when we move from one page to another in trade in.

What is the new behavior after the fix?
Reading header text when we move from one window to another

Root cause. When did the breakage start to happen in production?
“UIAccessibilityScreenChangedNotification was being posted for two UI components, $header and $disclaimer. This was leading to skipping the header being read out first and since the disclaimer is blank in this case the VO control was going to the just previous component of NO button”

How/Where did you test your change?
Ce04, iPhone 12mini device

Link to other PRs dependent to this change (config, client, server)
N/A

Previous PRs(list all) that this is a fix for


Which other areas should QA do regression on?

N/A