### PR TITLE
Test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,4 +25,5 @@ jobs:
           python ./scripts/run.py
         env: # Or as an environment variable  
           PAT: ${{ secrets.PAT }}
+          PR_NUM: ${{ github.event.pull_request.number }}
        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: py
 # on:
-on: [push, pull_request]
+on: [pull_request]
 #   workflow_dispatch:
 #     inputs:
 #       version:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# spring-boot-angular-test
+# spring-boot-angular

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# spring-boot-angular-examples
+# spring-boot-angular-test

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -45,8 +45,8 @@ def check_pr():
             #     result = get_string_between(comment["body"], questions[index], questions[index+1])
             #     print(result)
         else:
-            print('Not all questions are present in the description') 
-            raise PRException("Not all questions are present in the description")
+            print('Some of the questions are not present in the description') 
+            raise PRException("Some of the questions are not present in the description")
 
 
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -42,7 +42,9 @@ def check_pr():
             
             last_question_ans = get_string_after(comment["body"], questions[-1])
             print(last_question_ans)                                                                        
-            
+            if(len(last_question_ans) < 3):
+                print(f"{questions[-1]} not answered")
+                raise PRException(f"{questions[-1]} not answered")
             # for index, question in enumerate(questions):
             #     # print(question)
             #     result = get_string_between(comment["body"], questions[index], questions[index+1])

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,4 +1,5 @@
 import requests
+import os
 
 class PRException(Exception):
     pass
@@ -9,7 +10,8 @@ def check_pr():
     repo = "spring-boot-angular-examples"
 
     # Set the authentication parameters (if necessary)
-    auth = ("Anoopkr", "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")
+    PAT = os.getenv("PAT")
+    auth = ("Anoopkr", PAT)
 
     # Set the headers
     headers = {"Accept": "application/vnd.github+json"}

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -38,6 +38,7 @@ def check_pr():
                 comment = response.json()
                 print(comment["body"])
                 if comment["body"] is None:
+                     print(os.getenv("PR_NUM"))
                      print(f"No description")
                      raise PRException("No description")
                 if all_elements_in_string(questions, comment["body"]):

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -39,7 +39,10 @@ def check_pr():
                     print(f"{questions[count]} not answered")
                     raise PRException(f"{questions[count]} not answered")
                 count += 1
-
+            
+            last_question_ans = get_string_after(comment["body"], questions[-1)
+            print(last_question_ans)                                                                        
+            
             # for index, question in enumerate(questions):
             #     # print(question)
             #     result = get_string_between(comment["body"], questions[index], questions[index+1])
@@ -62,5 +65,12 @@ def get_string_between(paragraph, start_string, end_string):
     if end_index == -1:
         return ""
     return paragraph[start_index + len(start_string):end_index]
+
+def get_string_after(string, substring):
+    try:
+        index = string.index(substring)
+        return string[index + len(substring):]
+    except ValueError:
+        return ''
 
 check_pr()

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -17,7 +17,7 @@ def check_pr():
     headers = {"Accept": "application/vnd.github+json"}
 
     questions = ["Is this a fix for something broken from the user perspective? What is broken?", "What is the new behavior after the fix?", "Root cause. When did the breakage start to happen in production?",
-                "How/Where did you test your change?", "Link to other PRs dependent to this change (config, client, server)", "Previous PRs(list all) that this is a fix for", "Which other areas should QA do regression"]
+                "How/Where did you test your change?", "Link to other PRs dependent to this change (config, client, server)", "Previous PRs(list all) that this is a fix for", "Which other areas should QA do regression on?"]
 
     pr_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{os.getenv('PR_NUM')}"
     print(pr_url)

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -16,53 +16,39 @@ def check_pr():
     # Set the headers
     headers = {"Accept": "application/vnd.github+json"}
 
-    # questions1 = ["Is this a fix for something broken from the user perspective? What is broken?", "What is the new behavior after the fix?", "Root cause. When did the breakage start to happen in production?",
-    #             "How/Where did you test your change?", "Link to other PRs dependent to this change (config, client, server)", "Previous PRs(list all) that this is a fix for", "Which other areas should QA do regression on?"]
-
     questions = ["Is this a fix for something broken from the user perspective? What is broken?", "What is the new behavior after the fix?", "Root cause. When did the breakage start to happen in production?",
                 "How/Where did you test your change?", "Link to other PRs dependent to this change (config, client, server)", "Previous PRs(list all) that this is a fix for", "Which other areas should QA do regression"]
 
-    # Send the GET request
-    response = requests.get(
-        f"https://api.github.com/repos/{owner}/{repo}/pulls", auth=auth, headers=headers)
-
-    # Check for a successful response
+    pr_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{os.getenv("PR_NUM")}"
+    print(pr_url)
+    response = requests.get(pr_url, auth=auth, headers=headers)
     if response.status_code == 200:
-        # Print the list of pull requests
-        pull_requests = response.json()
-        for pull_request in pull_requests:
-            print(pull_request["url"])
-            response = requests.get(
-                f"{pull_request['url']}", auth=auth, headers=headers)
-            if response.status_code == 200:
-                comment = response.json()
-                print(comment["body"])
-                if comment["body"] is None:
-                     print(os.getenv("PR_NUM"))
-                     print(f"No description")
-                     raise PRException("No description")
-                if all_elements_in_string(questions, comment["body"]):
-                    print('All questions are present in the description')
-                    count = 0
+        comment = response.json()
+        print(comment["body"])
+        if comment["body"] is None:
+             print(os.getenv("PR_NUM"))
+             print(f"No description")
+             raise PRException("No description")
+        if all_elements_in_string(questions, comment["body"]):
+            print('All questions are present in the description')
+            count = 0
 
-                    while count < len(questions)-1:
-                        result = get_string_between(comment["body"], questions[count], questions[count+1])
-                        if len(result.strip()) < 3:
-                            print(f"{questions[count]} not answered")
-                            raise PRException(f"{questions[count]} not answered")
-                        count += 1
+            while count < len(questions)-1:
+                result = get_string_between(comment["body"], questions[count], questions[count+1])
+                if len(result.strip()) < 3:
+                    print(f"{questions[count]} not answered")
+                    raise PRException(f"{questions[count]} not answered")
+                count += 1
 
-                    # for index, question in enumerate(questions):
-                    #     # print(question)
-                    #     result = get_string_between(comment["body"], questions[index], questions[index+1])
-                    #     print(result)
-                else:
-                    print('Not all questions are present in the description') 
-                    raise PRException("Not all questions are present in the description")
+            # for index, question in enumerate(questions):
+            #     # print(question)
+            #     result = get_string_between(comment["body"], questions[index], questions[index+1])
+            #     print(result)
+        else:
+            print('Not all questions are present in the description') 
+            raise PRException("Not all questions are present in the description")
 
-    else:
-        # Print the error message
-        print(response.json()["message"])
+
 
 
 def all_elements_in_string(elements, string):

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,16 +1,15 @@
 import requests
-import os
+
+class PRException(Exception):
+    pass
 
 def check_pr():
     # Set the repository owner and name
     owner = "Anoopkr"
     repo = "spring-boot-angular-examples"
 
-    PAT = os.getenv("PAT")
-    print(PAT)
-
     # Set the authentication parameters (if necessary)
-    auth = ("Anoopkr", PAT)
+    auth = ("Anoopkr", "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")
 
     # Set the headers
     headers = {"Accept": "application/vnd.github+json"}
@@ -35,10 +34,10 @@ def check_pr():
                 f"{pull_request['url']}", auth=auth, headers=headers)
             if response.status_code == 200:
                 comment = response.json()
-                # print(comment["body"])
+                print(comment["body"])
                 if comment["body"] is None:
                      print(f"No description")
-                     return
+                     raise PRException("No description")
                 if all_elements_in_string(questions, comment["body"]):
                     print('All questions are present in the description')
                     count = 0

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -48,7 +48,7 @@ def check_pr():
                         result = get_string_between(comment["body"], questions[count], questions[count+1])
                         if len(result.strip()) < 3:
                             print(f"{questions[count]} not answered")
-                        # print(len(result.strip()))
+                            raise PRException(f"{questions[count]} not answered")
                         count += 1
 
                     # for index, question in enumerate(questions):
@@ -57,6 +57,7 @@ def check_pr():
                     #     print(result)
                 else:
                     print('Not all questions are present in the description') 
+                    raise PRException("Not all questions are present in the description")
 
     else:
         # Print the error message

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -19,7 +19,7 @@ def check_pr():
     questions = ["Is this a fix for something broken from the user perspective? What is broken?", "What is the new behavior after the fix?", "Root cause. When did the breakage start to happen in production?",
                 "How/Where did you test your change?", "Link to other PRs dependent to this change (config, client, server)", "Previous PRs(list all) that this is a fix for", "Which other areas should QA do regression"]
 
-    pr_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{os.getenv("PR_NUM")}"
+    pr_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{os.getenv('PR_NUM')}"
     print(pr_url)
     response = requests.get(pr_url, auth=auth, headers=headers)
     if response.status_code == 200:

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -40,7 +40,7 @@ def check_pr():
                     raise PRException(f"{questions[count]} not answered")
                 count += 1
             
-            last_question_ans = get_string_after(comment["body"], questions[-1)
+            last_question_ans = get_string_after(comment["body"], questions[-1])
             print(last_question_ans)                                                                        
             
             # for index, question in enumerate(questions):

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -36,6 +36,9 @@ def check_pr():
             if response.status_code == 200:
                 comment = response.json()
                 # print(comment["body"])
+                if comment["body"] is None:
+                     print(f"No description")
+                     return
                 if all_elements_in_string(questions, comment["body"]):
                     print('All questions are present in the description')
                     count = 0


### PR DESCRIPTION
Description in two sentences or less:

Apple Trade In: Voice over reads 'Yes' or 'No' as buttons without selecting it in Tradein flow. UIAccessibilityScreenChangedNotification was being posted for two UI components, $header and $disclaimer. This was leading to skipping the header being read out first and since the disclaimer is blank in this case the VO control was going to the just previous component of NO button

Testing Instructions

Steps To Reproduce:

Launch the Apple Store Application.
Navigate to the Mac/iPad/Apple Watch family landing page
Select any modal and go to Product description page
Select required variants to enable the 'Apple Trade In' section.
Click on 'Get started' link
Go to the 'Is your iPhone is good condition?' screen
By default reads as 'Yes' and 'No' without selecting buttons instead read firstly 'Header' texts.
Expected Results:

As soon as landing on the page then Voice Over should read header first i.e 'Is your iPhone in good condition.

Info

Is this a fix for something broken from the user perspective? What is broken?
Yes, voice over not reading header text when we move from one page to another in trade in.

What is the new behavior after the fix?
Reading header text when we move from one window to another

Root cause. When did the breakage start to happen in production?
“UIAccessibilityScreenChangedNotification was being posted for two UI components, $header and $disclaimer. This was leading to skipping the header being read out first and since the disclaimer is blank in this case the VO control was going to the just previous component of NO button”

How/Where did you test your change?
Ce04, iPhone 12mini device

Link to other PRs dependent to this change (config, client, server)
N/A

Previous PRs(list all) that this is a fix for

N/A

Which other areas should QA do regression on?
Last question ans